### PR TITLE
Added the option to configure the resource owner.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,8 @@
 Changelog
 =========
+
+## 0.1.3
+*[#4](https://github.com/antek-drzewiecki/wine_bouncer/pull/4): Support for newer versions of grape ( > 0.8 ).
+*[#6](https://github.com/antek-drzewiecki/wine_bouncer/pull/6): Added the option to configure the resource owner.
+
+*[#pull-request-id](link-to-pull-request): Some text explaining what changed in your commit. 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,4 +1,22 @@
 Upgrading WineBouncer
 =====================
 
+
+### Upgrading to >= 0.1.3
+
+To use the `resource_owner` you now need to define how WineBouncer gets the resource owner. In most cases he needs to return the User that is logged in, but not in all cases.
+You now additionally need to specify `define_resource_owner` in your configuration. Mostly this the following code will work:
+
+``` ruby
+WineBouncer.configure do |c|
+  .......
+  c.define_resource_owner do
+    User.find(doorkeeper_access_token.resource_owner_id) if doorkeeper_access_token
+  end
+end
+```
+
+The required Grape version is now from 0.8 and above.
+
+------
 From version 0.1.0 upgrade instructions are given.

--- a/lib/wine_bouncer/auth_methods/auth_methods.rb
+++ b/lib/wine_bouncer/auth_methods/auth_methods.rb
@@ -11,7 +11,7 @@ module WineBouncer
     end
 
     def resource_owner
-      User.find(doorkeeper_access_token.resource_owner_id) if doorkeeper_access_token
+       instance_eval(&WineBouncer.configuration.defined_resource_owner)
     end
 
     def client_credential_token?

--- a/lib/wine_bouncer/configuration.rb
+++ b/lib/wine_bouncer/configuration.rb
@@ -7,6 +7,7 @@ module WineBouncer
   class Configuration
 
     attr_accessor :auth_strategy
+    attr_accessor :defined_resource_owner
 
     def auth_strategy=(strategy)
       @auth_strategy= strategy
@@ -18,6 +19,16 @@ module WineBouncer
 
     def require_strategies
       require "wine_bouncer/auth_strategies/#{auth_strategy}"
+    end
+
+    def define_resource_owner &block
+      fail(ArgumentError, 'define_resource_owner expects a block in the configuration') unless block_given?
+      @defined_resource_owner = block
+    end
+
+    def defined_resource_owner
+      fail(Errors::UnconfiguredError, 'Please define define_resource_owner to configure the resource owner') unless @defined_resource_owner
+      @defined_resource_owner
     end
   end
 

--- a/lib/wine_bouncer/oauth2.rb
+++ b/lib/wine_bouncer/oauth2.rb
@@ -79,14 +79,13 @@ module WineBouncer
       unless valid_doorkeeper_token?(*scopes)
         if !doorkeeper_token || !doorkeeper_token.accessible?
           error = Doorkeeper::OAuth::InvalidTokenResponse.from_access_token(doorkeeper_token)
+          # TODO: localization and better error reporting
           raise WineBouncer::Errors::OAuthUnauthorizedError, 'unauthorized'
         else
           error = Doorkeeper::OAuth::ForbiddenTokenResponse.from_scopes(scopes)
+          # TODO: localization and better error reporting
           raise WineBouncer::Errors::OAuthForbiddenError, "missing permissions"
         end
-
-        # headers.merge!(error.headers.reject { |k| ['Content-Type'].include? k })
-        # doorkeeper_error_renderer(error, options)
       end
     end
 

--- a/spec/intergration/oauth2_default_strategy_spec.rb
+++ b/spec/intergration/oauth2_default_strategy_spec.rb
@@ -10,6 +10,10 @@ describe Api::MountedDefaultApiUnderTest, type: :api do
   before (:example) do
     WineBouncer.configure do |c|
       c.auth_strategy = :default
+
+      c.define_resource_owner do
+        User.find(doorkeeper_access_token.resource_owner_id) if doorkeeper_access_token
+      end
     end
   end
 

--- a/spec/intergration/oauth2_swagger_strategy_spec.rb
+++ b/spec/intergration/oauth2_swagger_strategy_spec.rb
@@ -11,6 +11,10 @@ describe Api::MountedSwaggerApiUnderTest, type: :api do
   before (:example) do
     WineBouncer.configure do |c|
       c.auth_strategy = :swagger
+
+      c.define_resource_owner do
+        User.find(doorkeeper_access_token.resource_owner_id) if doorkeeper_access_token
+      end
     end
   end
 

--- a/spec/lib/wine_bouncer/auth_methods/auth_methods_spec.rb
+++ b/spec/lib/wine_bouncer/auth_methods/auth_methods_spec.rb
@@ -15,7 +15,6 @@ describe ::WineBouncer::AuthMethods do
       tested_class.doorkeeper_access_token = token
       expect(tested_class.doorkeeper_access_token).to eq(token)
     end
-
   end
 
   context 'has_resource_owner?' do
@@ -82,6 +81,26 @@ describe ::WineBouncer::AuthMethods do
 
     it 'defaults returns false if not set' do
       expect(tested_class.protected_endpoint?).to be false
+    end
+  end
+
+
+  context 'resource_owner' do
+    it 'runs the configured block' do
+      result = 'called block'
+      foo = Proc.new { result }
+
+      WineBouncer.configure do |c|
+        c.auth_strategy = :default
+        c.define_resource_owner &foo
+      end
+
+      expect(tested_class.resource_owner).to be(result)
+    end
+
+    it 'raises an argument error when the block is not configured' do
+      WineBouncer.configuration= WineBouncer::Configuration.new
+      expect { tested_class.resource_owner }.to raise_error(WineBouncer::Errors::UnconfiguredError)
     end
   end
 end


### PR DESCRIPTION
Since Doorkeeper allows the configuration of the resource owner of an access token, WineBouncer should also make his resource owner configurable. Since the entity that belongs to the access token is not always a `User`. With this pull request you can now specify the entity the access token belongs to. For example if the entity is an `Admin`, you can now define the resource owner as `Admin` with the configuration block `Admin.find(doorkeeper_access_token.resource_owner_id) if doorkeeper_access_token`
