### PR TITLE
Doorkeeper 2.0 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,10 @@ rvm:
 env:
   - rails=3.2.18 grape=0.8.0
   - rails=4.1.1 grape=0.8.0
+  - rails=3.2.18 grape=0.9.0 doorkeeper=1.4.1
   - rails=3.2.18 grape=0.9.0
+  - rails=4.1.1 grape=0.9.0 doorkeeper=1.4.1
   - rails=4.1.1 grape=0.9.0
-  - rails=4.1.1 grape=0.9.0 doorkeeper=2.0.0.alpha1
 addons:
   code_climate:
     repo_token: ab1b6ce5f973da033f80ae2e99fadbb32b2f9c37892703956d8ef954c8e8134e

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,11 @@ rvm:
   - 2.0
   - 2.1
 env:
-  - rails=3.1.12 grape=0.8.0
   - rails=3.2.18 grape=0.8.0
-  - rails=4.0.5 grape=0.8.0
   - rails=4.1.1 grape=0.8.0
-  - rails=3.1.12 grape=0.9.0
   - rails=3.2.18 grape=0.9.0
-  - rails=4.0.5 grape=0.9.0
   - rails=4.1.1 grape=0.9.0
+  - rails=4.1.1 grape=0.9.0 doorkeeper=2.0.0.alpha1
 addons:
   code_climate:
     repo_token: ab1b6ce5f973da033f80ae2e99fadbb32b2f9c37892703956d8ef954c8e8134e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+## 0.2.1
+*[#7](https://github.com/antek-drzewiecki/wine_bouncer/pull/7): Added support for Doorkeeper 2.0.0 and 2.0.1. Thanks @whatasunnyday .
+
 ## 0.2.0
 *[#4](https://github.com/antek-drzewiecki/wine_bouncer/pull/4): Support for newer versions of grape ( > 0.8 ).
 *[#6](https://github.com/antek-drzewiecki/wine_bouncer/pull/6): Added the option to configure the resource owner.

--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,13 @@ source 'https://rubygems.org'
 
 ENV['grape'] ||= '0.9.0'
 ENV['rails'] ||= '4.1.1'
+ENV['doorkeeper'] ||= '1.4.0'
 
 gem 'rails', ENV['rails']
 
 gem 'activerecord'
 gem 'grape', ENV['grape']
+gem 'doorkeeper', ENV['doorkeeper']
 
 gem "codeclimate-test-reporter", group: :test, require: nil
 

--- a/Gemfile
+++ b/Gemfile
@@ -10,9 +10,7 @@ gem 'activerecord'
 gem 'grape', ENV['grape']
 gem 'doorkeeper', ENV['doorkeeper']
 
-gem "codeclimate-test-reporter", group: :test, require: nil
+gem 'codeclimate-test-reporter', group: :test, require: nil
 
 # Specify your gem's dependencies in wine_bouncer.gemspec
 gemspec
-
-

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Code Climate](https://codeclimate.com/github/antek-drzewiecki/wine_bouncer/badges/gpa.svg)](https://codeclimate.com/github/antek-drzewiecki/wine_bouncer)
 [![Gem Version](https://badge.fury.io/rb/wine_bouncer.svg)](http://badge.fury.io/rb/wine_bouncer)
 
-Protect your precious Grape API with Doorkeeper. 
+Protect your precious Grape API with Doorkeeper.
 WineBouncer uses minimal modification, to make the magic happen.
 
 Table of Contents
@@ -24,7 +24,7 @@ Table of Contents
 
 ## Requirements
 - Ruby > 1.9.3
-- Doorkeeper > 1.4.0
+- Doorkeeper > 1.4.0 and =< 2.0.1
 - Grape > 0.8
 
 ## Installation
@@ -45,7 +45,7 @@ bundle
 When upgrading from a previous version, see [UPGRADING](UPGRADING.md). You might also be interested at the [CHANGELOG](CHANGELOG.md).
 
 ## Usage
-WineBouncer is a custom Grape Middleware used for Authentication and Authorization. We assume you have a Grape API mounted in your Rails application together with Doorkeeper.  
+WineBouncer is a custom Grape Middleware used for Authentication and Authorization. We assume you have a Grape API mounted in your Rails application together with Doorkeeper.
 
 To get started with WineBouncer, create a rails initializer in your Rails app at `config/initializers/wine_bouncer.rb` with the following configuration.
 
@@ -70,7 +70,7 @@ class Api < Grape::API
 end
 ```
 
-WineBouncer relies on Grape's endpoint method description to define if an endpoint method should be protected. 
+WineBouncer relies on Grape's endpoint method description to define if an endpoint method should be protected.
 It comes with authorization strategies that allow a custom format for your authorization definition. Pick an authentication strategy to get started.
 Currently the following strategies are included:
 
@@ -84,30 +84,30 @@ Example:
 
 ``` ruby
  class MyAwesomeAPI < Grape::API
-    desc 'protected method with required public scope', 
+    desc 'protected method with required public scope',
     auth: { scopes: ['public'] }
     get '/protected' do
        { hello: 'world' }
     end
-    
+
     desc 'Unprotected method'
     get '/unprotected' do
       { hello: 'unprotected world' }
     end
-    
+
     desc 'This method needs the public or private scope.',
     auth: { scopes: [ 'public', 'private' ] }
     get '/method' do
       { hello: 'public or private user.' }
     end
-    
-    desc 'This method uses Doorkeepers default scopes.', 
-    auth: { scopes: [] } 
+
+    desc 'This method uses Doorkeepers default scopes.',
+    auth: { scopes: [] }
     get '/protected_with_default_scope' do
        { hello: 'protected unscoped world' }
     end
  end
- 
+
  class Api < Grape::API
     default_format :json
     format :json
@@ -122,7 +122,7 @@ Example:
 
 WineBouncer comes with a strategy that can be perfectly used with [grape-swagger](https://github.com/tim-vandecasteele/grape-swagger) with a syntax compliant with the [swagger spec](https://github.com/wordnik/swagger-spec/).
 This might be one of the simplest methods to protect your API and serve it with documentation. You can use [swagger-ui](https://github.com/wordnik/swagger-ui) to view your documentation.
- 
+
 To get started ensure you also have included the `grape-swagger` gem in your gemfile.
 
 Run `bundle` to install the missing gems.
@@ -192,7 +192,7 @@ You can use the default scopes of Doorkeeper by just adding `authorizations: { o
 
 ### Token information
 
-WineBouncer comes with free extras! Methods for `resource_owner` and `doorkeeper_access_token` get included in your endpoints. You can use them to get the current resource owner, and the access_token object of doorkeeper. 
+WineBouncer comes with free extras! Methods for `resource_owner` and `doorkeeper_access_token` get included in your endpoints. You can use them to get the current resource owner, and the access_token object of doorkeeper.
 
 ## Exceptions and Exception handling
 
@@ -200,12 +200,12 @@ This gem raises the following exceptions which can be handled in your Grape API,
 
 * `WineBouncer::Errors::OAuthUnauthorizedError`
    when the request is unauthorized.
-* `WineBouncer::Errors::OAuthForbiddenError` 
+* `WineBouncer::Errors::OAuthForbiddenError`
    when the token is found but scopes do not match.
 
 ## Development
 
-Since we want the gem tested against several rails versions we use the same way to prepare our development environment as Doorkeeper. 
+Since we want the gem tested against several rails versions we use the same way to prepare our development environment as Doorkeeper.
 
 To install the development environment for rails 3.2.18, you can also specify a different rails version to test against.
 

--- a/spec/lib/wine_bouncer/auth_methods/auth_methods_spec.rb
+++ b/spec/lib/wine_bouncer/auth_methods/auth_methods_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe ::WineBouncer::AuthMethods do
 

--- a/spec/lib/wine_bouncer/auth_strategies/default_spec.rb
+++ b/spec/lib/wine_bouncer/auth_strategies/default_spec.rb
@@ -1,10 +1,10 @@
-require 'spec_helper'
+require 'rails_helper'
 require 'wine_bouncer/auth_strategies/default'
 
 describe ::WineBouncer::AuthStrategies::Default do
   subject(:klass) { ::WineBouncer::AuthStrategies::Default.new }
 
-  let(:scopes) { [ 'public', 'private' ] }
+  let(:scopes) { %w(public private) }
   let(:scopes_hash) { { scopes: scopes } }
   let(:auth_context) { { auth: scopes_hash } }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,9 +7,6 @@ require 'rspec/rails'
 require 'wine_bouncer'
 require 'factory_girl'
 require 'database_cleaner'
-require "codeclimate-test-reporter"
-
-CodeClimate::TestReporter.start
 
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,8 +1,8 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-ENV["RAILS_ENV"] ||= 'test'
+ENV['RAILS_ENV'] ||= 'test'
 ORM = (ENV['orm'] || :active_record).to_sym
 require 'spec_helper'
-require File.expand_path("../dummy/config/environment", __FILE__)
+require File.expand_path('../dummy/config/environment', __FILE__)
 require 'rspec/rails'
 require 'wine_bouncer'
 require 'factory_girl'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,8 @@
 # users commonly want.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+require "codeclimate-test-reporter"
+CodeClimate::TestReporter.start
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate

--- a/wine_bouncer.gemspec
+++ b/wine_bouncer.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency 'grape', '~> 0.8'
-  spec.add_runtime_dependency 'doorkeeper', '~> 1.4.0'
+  spec.add_runtime_dependency 'doorkeeper', '>= 1.4', '<= 2.0.0.alpha1'
 
   spec.add_development_dependency "railties"
   spec.add_development_dependency "bundler", "~> 1.7"


### PR DESCRIPTION
This branch adds wine_bouncer support for Doorkeeper 2.0. Currently it only supports the alpha candidate until doorkeeper is released.