### PR TITLE
Add protected strategy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Table of Contents
     * [Authentication strategies](#authentication-strategies)
       * [Default](#default)
       * [Swagger](#swagger)
+      * [Protected](#protected)
     * [Token information](#token-information)
   * [Exceptions and Exception handling](#exceptions-and-exception-handling)
   * [Development](#development)
@@ -195,6 +196,48 @@ The Swagger strategy uses the `authorizations: { oauth2: [] }` in the method des
 It defaults assumes when no description is given that no authorization should be used like the `/unprotected` method.
 When the authentication syntax is mentioned in the method description, the method will be protected.
 You can use the default scopes of Doorkeeper by just adding `authorizations: { oauth2: [] }` or state your own scopes with `authorizations: { oauth2: [ { scope: 'scope1' }, { scope: 'scope2' }, ... ] }`.
+
+#### Protected
+
+The protected strategy is very similiar to the default strategy except any public end point must explicitly set. To make an end point public, use `auth: false`. 
+If the authorization is not set, the end point is assumed to be protected and Doorkeeper's default scopes are used.
+
+Example:
+
+``` ruby
+ class MyAwesomeAPI < Grape::API
+    desc 'protected method with required public scope', 
+    auth: { scopes: ['public'] }
+    get '/protected' do
+       { hello: 'world' }
+    end
+    
+    desc 'Unprotected method'
+    get '/unprotected', auth: false do
+      { hello: 'unprotected world' }
+    end
+    
+    desc 'This method needs the public or private scope.',
+    auth: [:public, :private]
+    # Doorkeeper's default scopes are [:public, :private] so auth can be omitted. See next example.
+    get '/method' do
+      { hello: 'public or private user.' }
+    end
+    
+    desc 'This method uses Doorkeepers default scopes.'
+    get '/protected_with_default_scope' do
+       { hello: 'protected unscoped world' }
+    end
+ end
+ 
+ class Api < Grape::API
+    default_format :json
+    format :json
+    use ::WineBouncer::OAuth2
+    mount MyAwesomeAPI
+    add_swagger_documentation
+ end
+```
 
 ### Token information
 

--- a/lib/wine_bouncer/auth_strategies/protected.rb
+++ b/lib/wine_bouncer/auth_strategies/protected.rb
@@ -1,0 +1,35 @@
+module WineBouncer
+  module AuthStrategies
+    class Protected
+
+      def endpoint_protected?(context)
+        has_authorizations?(context)
+      end
+
+      def has_auth_scopes?(context)
+        endpoint_authorizations(context) && 
+          endpoint_authorizations(context).has_key?(:scopes) && 
+          endpoint_authorizations(context)[:scopes].any?
+      end
+
+      def auth_scopes(context)
+        endpoint_authorizations(context)[:scopes].map(&:to_sym)
+      end
+
+      private
+
+      def nil_authorizations?(context)
+        endpoint_authorizations(context).nil?
+      end
+
+
+      def has_authorizations?(context)
+        nil_authorizations?(context) || endpoint_authorizations(context)
+      end
+
+      def endpoint_authorizations(context)
+         context[:auth]
+      end
+    end
+  end
+end

--- a/spec/dummy/app/api/protected_api.rb
+++ b/spec/dummy/app/api/protected_api.rb
@@ -1,0 +1,39 @@
+module Api
+
+  ###
+  # Api under test, default doorkeeper scope is 'account'
+  ##
+  class MountedProtectedApiUnderTest < Grape::API
+    desc 'Protected method with public', auth: { scopes: ['public'] }
+    get '/protected' do
+      { hello: 'world' }
+    end
+
+    desc 'Protected method with private', auth: { scopes: ['private'] }
+    get '/protected_with_private_scope' do
+      { hello: 'scoped world' }
+    end
+
+    desc 'Unprotected method'
+    get '/unprotected', auth: false do
+      { hello: 'unprotected world' }
+    end
+
+    desc 'Protected method with public that returns the user name', auth: { scopes: ['public'] }
+    get '/protected_user' do
+      { hello: resource_owner.name }
+    end
+
+    desc 'This method uses Doorkeepers default scopes'
+    get '/protected_without_scope' do
+      { hello: 'protected unscoped world' }
+    end
+  end
+
+  class ProtectedApiUnderTest < Grape::API
+    default_format :json
+    format :json
+    use ::WineBouncer::OAuth2
+    mount MountedProtectedApiUnderTest
+  end
+end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   use_doorkeeper
   mount Api::DefaultApiUnderTest => '/default_api'
   mount Api::SwaggerApiUnderTest => '/swagger_api'
+  mount Api::ProtectedApiUnderTest => '/protected_api'
 end

--- a/spec/intergration/oauth2_protected_strategy_spec.rb
+++ b/spec/intergration/oauth2_protected_strategy_spec.rb
@@ -1,0 +1,97 @@
+require 'rails_helper'
+require 'json'
+
+describe Api::MountedProtectedApiUnderTest, type: :api do
+
+  let(:user) { FactoryGirl.create :user }
+  let(:token) { FactoryGirl.create :clientless_access_token, resource_owner_id: user.id, scopes: "public" }
+  let(:unscoped_token) { FactoryGirl.create :clientless_access_token, resource_owner_id: user.id, scopes: "" }
+
+  before (:example) do
+    WineBouncer.configure do |c|
+      c.auth_strategy = :protected
+
+      c.define_resource_owner do
+        User.find(doorkeeper_access_token.resource_owner_id) if doorkeeper_access_token
+      end
+    end
+  end
+
+  context 'tokens and scopes' do
+    it 'gives access when the token and scope are correct' do
+      get '/protected_api/protected', nil, 'HTTP_AUTHORIZATION' => "Bearer #{token.token}"
+
+      expect(last_response.status).to eq(200)
+      json = JSON.parse(last_response.body)
+      expect(json).to have_key('hello')
+    end
+
+    it 'raises an authentication error when the token is invalid' do
+      expect { get '/protected_api/protected', nil, 'HTTP_AUTHORIZATION' => "Bearer #{token.token}-invalid" }.to raise_exception(WineBouncer::Errors::OAuthUnauthorizedError)
+    end
+
+    it 'raises an oauth authentication error when no token is given' do
+      expect { get '/protected_api/protected' }.to raise_exception(WineBouncer::Errors::OAuthUnauthorizedError)
+    end
+
+    it 'raises an auth forbidden authentication error when the user scope is not correct' do
+      expect { get '/protected_api/protected_with_private_scope', nil, 'HTTP_AUTHORIZATION' => "Bearer #{token.token}" }.to raise_exception(WineBouncer::Errors::OAuthForbiddenError)
+    end
+  end
+
+  context 'unprotected endpoint' do
+    it 'allows to call an unprotected endpoint without token' do
+      get '/protected_api/unprotected'
+
+      expect(last_response.status).to eq(200)
+      json = JSON.parse(last_response.body)
+
+      expect(json).to have_key('hello')
+      expect(json['hello']).to eq('unprotected world')
+    end
+
+    it 'allows to call an unprotected endpoint with token' do
+      get '/protected_api/unprotected', nil, 'HTTP_AUTHORIZATION' => "Bearer #{token.token}"
+
+      expect(last_response.status).to eq(200)
+      json = JSON.parse(last_response.body)
+      expect(json).to have_key('hello')
+      expect(json['hello']).to eq('unprotected world')
+    end
+  end
+
+  context 'protected_without_scopes' do
+    it 'does not allow an unauthenticated user to call a protected endpoint' do
+      expect { get '/protected_api/protected_without_scope' }.to raise_exception(WineBouncer::Errors::OAuthUnauthorizedError)
+    end
+
+    it 'allows to call an protected endpoint without scopes' do
+      get '/protected_api/protected_without_scope', nil, 'HTTP_AUTHORIZATION' => "Bearer #{token.token}"
+
+      expect(last_response.status).to eq(200)
+      json = JSON.parse(last_response.body)
+      expect(json).to have_key('hello')
+      expect(json['hello']).to eq('protected unscoped world')
+    end
+
+    it 'raises an error when an protected endpoint without scopes is called without token ' do
+      expect { get '/protected_api/protected_without_scope' }.to raise_exception(WineBouncer::Errors::OAuthUnauthorizedError)
+    end
+
+    it 'raises an error because the user does not have the default scope' do
+      expect { get '/protected_api/protected_without_scope', nil, 'HTTP_AUTHORIZATION' => "Bearer #{unscoped_token.token}" }.to raise_exception(WineBouncer::Errors::OAuthForbiddenError)
+    end
+  end
+
+  context 'resource_owner' do
+    it 'is available in the endpoint' do
+      get '/protected_api/protected_user', nil, 'HTTP_AUTHORIZATION' => "Bearer #{token.token}"
+
+      expect(last_response.status).to eq(200)
+      json = JSON.parse(last_response.body)
+
+      expect(json).to have_key('hello')
+      expect(json['hello']).to eq(user.name)
+    end
+  end
+end


### PR DESCRIPTION
Hello Antek,

I had to send a new PR because I force pushed. For my API, every end point is protected. I wanted to keep my code dry so I created a new strategy that by default protects every end point. I've updated the documentation to include an example. Let me know if there's any interest in this PR. If it's unneeded, feel free to leave it unmerged.