### PR TITLE
Fixes protected strategy endpoint authorization check for 0.3.0

### DIFF
--- a/lib/wine_bouncer/auth_strategies/protected.rb
+++ b/lib/wine_bouncer/auth_strategies/protected.rb
@@ -24,7 +24,7 @@ module WineBouncer
 
 
       def has_authorizations?
-        nil_authorizations? || endpoint_authorizations
+        !nil_authorizations? || api_context.options[:route_options][:oauth2]
       end
 
       def endpoint_authorizations

--- a/spec/dummy/app/api/protected_api.rb
+++ b/spec/dummy/app/api/protected_api.rb
@@ -15,7 +15,7 @@ module Api
     end
 
     desc 'Unprotected method'
-    get '/unprotected', auth: false do
+    get '/unprotected', oauth2: false do
       { hello: 'unprotected world' }
     end
 


### PR DESCRIPTION
I noticed this got missed in the update when ```oauth2: false``` wasn't working for me. Fixed the test for this particular issue, though still failing for something unrelated.

I'm not certain of your future plans with incorporating this into the DSL so feel free to reject in favor of your preferred methods (or I can change it to suit).
