### PR TITLE
Dsl strategy fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,9 @@ The Swagger strategy uses scopes and injects them in the authorizations descript
 
 #### Protected
 
-The protected strategy is very similar to the default strategy except any public end point must explicitly set. To make an end point public, use `oauth2: false`.
-If the authorization is not set, the end point is assumed to be protected and Doorkeeper's default scopes are used.
+The protected strategy is very similar to the default strategy except any public endpoint must explicitly set. To make an end point public, use `oauth2 false`.
+If the authorization method is not set, the end point is assumed to be __protected with Doorkeeper's default scopes__ (which is the same as `oauth2 nil `.)
+To protect your endpoint with other scopes append the following method `oauth2 'first scope', 'second scope'`.
 
 
 ### Token information

--- a/lib/wine_bouncer/auth_strategies/protected.rb
+++ b/lib/wine_bouncer/auth_strategies/protected.rb
@@ -32,7 +32,7 @@ module WineBouncer
       # if false or nil scopes are entered the authorization should be skipped.
       # nil_authorizations? is used to check against the legacy hash.
       def scope_keys?
-        nil_authorizations? || (!endpoint_authorizations[:scopes].empty? && (endpoint_authorizations[:scopes] != [false]))
+        nil_authorizations? || endpoint_authorizations[:scopes] != [false]
       end
 
       def endpoint_authorizations

--- a/lib/wine_bouncer/auth_strategies/protected.rb
+++ b/lib/wine_bouncer/auth_strategies/protected.rb
@@ -23,8 +23,16 @@ module WineBouncer
       end
 
 
+      # returns true if an authorization hash has been found
+      # First it checks for the old syntax, then for the new.
       def has_authorizations?
-        nil_authorizations? || endpoint_authorizations
+        (nil_authorizations? || !!endpoint_authorizations) && scope_keys?
+      end
+
+      # if false or nil scopes are entered the authorization should be skipped.
+      # nil_authorizations? is used to check against the legacy hash.
+      def scope_keys?
+        nil_authorizations? || (!endpoint_authorizations[:scopes].empty? && (endpoint_authorizations[:scopes] != [false]))
       end
 
       def endpoint_authorizations

--- a/lib/wine_bouncer/extension.rb
+++ b/lib/wine_bouncer/extension.rb
@@ -3,13 +3,13 @@ module WineBouncer
     def oauth2(*scopes)
       scopes = Array(scopes)
       description = if respond_to?(:route_setting) # >= grape-0.10.0
-        route_setting(:description)
+        route_setting(:description) || route_setting(:description, {})
       else
         @last_description ||= {}
       end
       # case WineBouncer.configuration.auth_strategy
       # when :default
-      description[:auth] = { scope: scopes }
+      description[:auth] = { scopes: scopes }
       # when :swagger
       description[:authorizations] = { oauth2: scopes.map{|x| {scope: x}} }
       # end

--- a/lib/wine_bouncer/version.rb
+++ b/lib/wine_bouncer/version.rb
@@ -1,3 +1,3 @@
 module WineBouncer
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end

--- a/spec/dummy/app/api/default_api.rb
+++ b/spec/dummy/app/api/default_api.rb
@@ -14,6 +14,11 @@ module Api
       { hello: 'scoped world' }
     end
 
+    desc 'Protected method with custom scope', auth: { scopes: ['custom_scope'] }
+    get '/oauth2_custom_scope' do
+      { hello: 'oauth2_custom_scope' }
+    end
+
     desc 'Unprotected method'
     get '/unprotected' do
       { hello: 'unprotected world' }
@@ -32,7 +37,12 @@ module Api
     desc 'oauth2_dsl'
     oauth2 'public'
     get '/oauth2_dsl' do
-      { hello: 'oauth2_dsl' }
+      { hello: 'oauth2 dsl' }
+    end
+
+    oauth2 'custom_scope'
+    get '/oauth2_dsl_custom_scope' do
+      { hello: 'oauth2 dsl custom scope' }
     end
 
     get '/not_described_world' do

--- a/spec/dummy/app/api/protected_api.rb
+++ b/spec/dummy/app/api/protected_api.rb
@@ -41,12 +41,12 @@ module Api
     end
 
     oauth2
-    get '/unprotected_endpoint' do
-      { hello: 'public oauth2 dsl' }
+    get '/oauth2_protected_with_default_scopes' do
+      { hello: 'default oauth2 dsl' }
     end
 
     oauth2 false
-    get '/unprotected_endpoints' do
+    get '/unprotected_endpoint' do
       { hello: 'public oauth2 dsl' }
     end
 

--- a/spec/dummy/app/api/protected_api.rb
+++ b/spec/dummy/app/api/protected_api.rb
@@ -35,6 +35,21 @@ module Api
       { hello: 'oauth2_dsl' }
     end
 
+    oauth2 'custom_scope'
+    get '/oauth2_dsl_custom_scope' do
+      { hello: 'custom scope' }
+    end
+
+    oauth2
+    get '/unprotected_endpoint' do
+      { hello: 'public oauth2 dsl' }
+    end
+
+    oauth2 false
+    get '/unprotected_endpoints' do
+      { hello: 'public oauth2 dsl' }
+    end
+
     get '/not_described_world' do
       { hello: 'non described world' }
     end

--- a/spec/intergration/oauth2_protected_strategy_spec.rb
+++ b/spec/intergration/oauth2_protected_strategy_spec.rb
@@ -6,6 +6,7 @@ describe Api::MountedProtectedApiUnderTest, type: :api do
   let(:user) { FactoryGirl.create :user }
   let(:token) { FactoryGirl.create :clientless_access_token, resource_owner_id: user.id, scopes: "public" }
   let(:unscoped_token) { FactoryGirl.create :clientless_access_token, resource_owner_id: user.id, scopes: "" }
+  let(:custom_scope) { FactoryGirl.create :clientless_access_token, resource_owner_id: user.id, scopes: "custom_scope" } #not a default scope
 
   before (:example) do
     WineBouncer.configure do |c|
@@ -93,6 +94,31 @@ describe Api::MountedProtectedApiUnderTest, type: :api do
       expect(json['hello']).to eq('oauth2_dsl')
 
     end
+
+    it 'allows to call an unprotected endpoint without scopes' do
+      get '/protected_api/unprotected_endpoint'
+      expect(last_response.status).to eq(200)
+      json = JSON.parse(last_response.body)
+      expect(json).to have_key('hello')
+      expect(json['hello']).to eq('public oauth2 dsl')
+    end
+
+    it 'allows to call an unprotected endpoint that has auth disabled' do
+      get '/protected_api/unprotected_endpoints'
+      expect(last_response.status).to eq(200)
+      json = JSON.parse(last_response.body)
+      expect(json).to have_key('hello')
+      expect(json['hello']).to eq('public oauth2 dsl')
+    end
+
+    it 'protects endpoints with custom scopes' do
+      get '/protected_api/oauth2_dsl_custom_scope', nil, 'HTTP_AUTHORIZATION' => "Bearer #{custom_scope.token}"
+      expect(last_response.status).to eq(200)
+      json = JSON.parse(last_response.body)
+      expect(json).to have_key('hello')
+      expect(json['hello']).to eq('custom scope')
+    end
+
 
     it 'raises an error when an protected endpoint without scopes is called without token ' do
       expect { get '/protected_api/oauth2_dsl' }.to raise_exception(WineBouncer::Errors::OAuthUnauthorizedError)


### PR DESCRIPTION
This branch fixes issues with uninitialised variables on the protected and default strategy spec. 
Custom scopes were not well handled. It fixes issue #26.

It also fixes issues with the protected strategy for the DSL. It fixes issue #24.
The readme is improved how to use the protected strategy.