### PR TITLE
Doorkeeper 2.2.x support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,10 @@ env:
   - rails=3.2.18 grape=0.10.0
   - rails=3.2.18 grape=0.12.0
   - rails=4.1.1 grape=0.12.0 doorkeeper=2.0.1
-  - rails=4.2.0 grape=0.10.0 doorkeeper=2.1.4
-  - rails=4.2.0 grape=0.11.0 doorkeeper=2.1.4
-  - rails=4.2.0 grape=0.12.0 doorkeeper=2.1.4
+  - rails=4.1.1 grape=0.12.0 doorkeeper=2.1.4
+  - rails=4.2.0 grape=0.10.0 doorkeeper=2.2.1
+  - rails=4.2.0 grape=0.11.0 doorkeeper=2.2.1
+  - rails=4.2.0 grape=0.12.0 doorkeeper=2.2.1
 matrix:
   exclude:
     - env: rails=3.2.18 grape=0.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,25 +2,26 @@ Changelog
 =========
 
 ## 0.4.0
-Added support for Grape 0.12.0, Removed support for Grape 0.8 and 0.9 (though they still work).
+Added support for Doorkeeper 2.2
+* [#41](https://github.com/antek-drzewiecki/wine_bouncer/pull/41): Added support for Grape 0.12.0, Removed support for Grape 0.8 and 0.9 (though they still work).
 
 ## 0.3.1
-[#31](https://github.com/antek-drzewiecki/wine_bouncer/pull/31): Improves support for default scopes trough DSL.
-[#30](https://github.com/antek-drzewiecki/wine_bouncer/pull/30): Restricted grape dependencies to the next minor level of grape.
-[#29](https://github.com/antek-drzewiecki/wine_bouncer/pull/29): Doorkeepers dependencies are restricted to minor levels. Thanks @nickcharlton
-[#27](https://github.com/antek-drzewiecki/wine_bouncer/pull/27): Fixes DSL default and protected strategy. Fixes #24 and #26.
+* [#31](https://github.com/antek-drzewiecki/wine_bouncer/pull/31): Improves support for default scopes trough DSL.
+* [#30](https://github.com/antek-drzewiecki/wine_bouncer/pull/30): Restricted grape dependencies to the next minor level of grape.
+* [#29](https://github.com/antek-drzewiecki/wine_bouncer/pull/29): Doorkeepers dependencies are restricted to minor levels. Thanks @nickcharlton
+* [#27](https://github.com/antek-drzewiecki/wine_bouncer/pull/27): Fixes DSL default and protected strategy. Fixes #24 and #26.
 
 ## 0.3.0
-[#21](https://github.com/antek-drzewiecki/wine_bouncer/pull/21): Added an Easy DSL for WineBouncer. Thanks @masarakki .
-[#23](https://github.com/antek-drzewiecki/wine_bouncer/pull/23): Added support for Doorkeeper 2.1.1 and refactored strategies.
+* [#21](https://github.com/antek-drzewiecki/wine_bouncer/pull/21): Added an Easy DSL for WineBouncer. Thanks @masarakki .
+* [#23](https://github.com/antek-drzewiecki/wine_bouncer/pull/23): Added support for Doorkeeper 2.1.1 and refactored strategies.
 
 ## 0.2.2
-[#17](https://github.com/antek-drzewiecki/wine_bouncer/pull/17): Added a new protected strategy. Thanks @whatasunnyday .
+* [#17](https://github.com/antek-drzewiecki/wine_bouncer/pull/17): Added a new protected strategy. Thanks @whatasunnyday .
 
 ## 0.2.1
-[#12](https://github.com/antek-drzewiecki/wine_bouncer/pull/12): Added a rails generator to generate the WineBouncer configuration file. Thanks @whatasunnyday.
-[#7](https://github.com/antek-drzewiecki/wine_bouncer/pull/7): Added support for Doorkeeper 2.0.0 and 2.0.1. Thanks @whatasunnyday .
+* [#12](https://github.com/antek-drzewiecki/wine_bouncer/pull/12): Added a rails generator to generate the WineBouncer configuration file. Thanks @whatasunnyday.
+* [#7](https://github.com/antek-drzewiecki/wine_bouncer/pull/7): Added support for Doorkeeper 2.0.0 and 2.0.1. Thanks @whatasunnyday .
 
 ## 0.2.0
-[#4](https://github.com/antek-drzewiecki/wine_bouncer/pull/4): Support for newer versions of grape ( > 0.8 ).
-[#6](https://github.com/antek-drzewiecki/wine_bouncer/pull/6): Added the option to configure the resource owner.
+* [#4](https://github.com/antek-drzewiecki/wine_bouncer/pull/4): Support for newer versions of grape ( > 0.8 ).
+* [#6](https://github.com/antek-drzewiecki/wine_bouncer/pull/6): Added the option to configure the resource owner.

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 ENV['grape'] ||= '0.12.0'
 ENV['rails'] ||= '4.2.0'
-ENV['doorkeeper'] ||= '2.1.4'
+ENV['doorkeeper'] ||= '2.2.1'
 
 gem 'rails', ENV['rails']
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Table of Contents
 
 ## Requirements
 - Ruby > 2.0
-- Doorkeeper > 1.4.0 and < 2.2
+- Doorkeeper > 1.4.0 and < 3
 - Grape > 0.10 and < 0.13
 
 ## Installation

--- a/wine_bouncer.gemspec
+++ b/wine_bouncer.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.name          = "wine_bouncer"
   spec.version       = WineBouncer::VERSION
   spec.authors       = ["Antek Drzewiecki"]
-  spec.email         = ["antek.drzewiecki@tass.nl"]
+  spec.email         = ["antek.drzewiecki@altran.com"]
   spec.summary       = %q{A Ruby gem that allows Oauth2 protection with Doorkeeper for Grape Api's}
   spec.homepage      = ""
   spec.license       = "MIT"
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency 'grape', '~> 0.10', '< 0.13'
-  spec.add_runtime_dependency 'doorkeeper', '>= 1.4', '< 2.2'
+  spec.add_runtime_dependency 'doorkeeper', '>= 1.4', '< 3.0'
 
   spec.add_development_dependency "railties"
   spec.add_development_dependency "bundler", "~> 1.7"


### PR DESCRIPTION
Adding doorkeeper 2.2.x to travis tests and allow support for these gems.