### PR TITLE
Doorkeeper 4.1 and 4.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,13 @@ env:
 
 - rails=4.2.6 grape=0.15.0 doorkeeper=3.1.0
 - rails=4.2.6 grape=0.15.0 doorkeeper=4.0.0
+- rails=4.2.6 grape=0.15.0 doorkeeper=4.1.0
+- rails=4.2.6 grape=0.15.0 doorkeeper=4.2.0
 - rails=4.2.6 grape=0.16.2 doorkeeper=3.1.0
 - rails=5.0.0 grape=0.16.2 doorkeeper=4.0.0
+- rails=5.0.0 grape=0.16.2 doorkeeper=4.1.0
+- rails=5.0.0 grape=0.16.2 doorkeeper=4.2.0
+
 addons:
   code_climate:
     repo_token: ab1b6ce5f973da033f80ae2e99fadbb32b2f9c37892703956d8ef954c8e8134e
@@ -26,3 +31,7 @@ matrix:
   exclude:
     - rvm: 2.1.0
       env: rails=5.0.0 grape=0.16.2 doorkeeper=4.0.0
+    - rvm: 2.1.0
+      env: rails=5.0.0 grape=0.16.2 doorkeeper=4.1.0
+    - rvm: 2.1.0
+      env: rails=5.0.0 grape=0.16.2 doorkeeper=4.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changelog
 =========
+## Unreleased
+* Support for Doorkeeper 4.1 and 4.2
+
 ## 1.0
 * [#61](https://github.com/antek-drzewiecki/wine_bouncer/pull/61): Travis cleanup Rails 4.1.x is EOL. Ruby 2.0 is unsupported.
 * [#60](https://github.com/antek-drzewiecki/wine_bouncer/pull/60): Rails 5, Doorkeeper 4, grape 0.16.2 support. Thanks @texpert

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ENV['grape'] ||= '0.16.2'
 ENV['rails'] ||= '5.0.0'
 ENV['doorkeeper'] ||= '4.0.0'
 
-ruby '>=2.2.2' if ENV['rails'][0].to_i > 4
+ruby '>= 2.2.2' if ENV['rails'][0].to_i > 4
 
 gem 'rails', ENV['rails']
 

--- a/wine_bouncer.gemspec
+++ b/wine_bouncer.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'grape', '~> 0.10', '< 1.0'
-  spec.add_runtime_dependency 'doorkeeper', '>= 1.4', '< 4.1'
+  spec.add_runtime_dependency 'doorkeeper', '>= 1.4', '< 4.3'
 
   spec.add_development_dependency 'railties'
   spec.add_development_dependency 'bundler', '~> 1.7'


### PR DESCRIPTION
Added support for doorkeeper 4.1 and 4.2.

Tests seems to be passing, added lines to `.travis.yml`