### PR TITLE
Update dependency to allow grape v1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,13 @@ env:
 - rails=5.0.0 grape=0.16.2 doorkeeper=4.0.0
 - rails=5.0.0 grape=0.16.2 doorkeeper=4.1.0
 - rails=5.0.0 grape=0.16.2 doorkeeper=4.2.0
+- rails=5.0.0 grape=1.0.0 doorkeeper=4.2.0
 
 addons:
   code_climate:
     repo_token: ab1b6ce5f973da033f80ae2e99fadbb32b2f9c37892703956d8ef954c8e8134e
+  after_success:
+    - bundle exec codeclimate-test-reporter
 notifications:
   hipchat:
     rooms:
@@ -35,3 +38,5 @@ matrix:
       env: rails=5.0.0 grape=0.16.2 doorkeeper=4.1.0
     - rvm: 2.1.0
       env: rails=5.0.0 grape=0.16.2 doorkeeper=4.2.0
+    - rvm: 2.1.0
+      env: rails=5.0.0 grape=1.0.0 doorkeeper=4.2.0

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-ENV['grape'] ||= '0.16.2'
+ENV['grape'] ||= '1.0.0'
 ENV['rails'] ||= '5.0.0'
 ENV['doorkeeper'] ||= '4.0.0'
 

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'grape', ENV['grape']
 gem 'doorkeeper', ENV['doorkeeper']
 
 gem 'codeclimate-test-reporter', group: :test, require: nil
+gem 'simplecov', :require => false, :group => :test
 
 # Specify your gem's dependencies in wine_bouncer.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Table of Contents
 ## Requirements
 - Ruby > 2.0
 - Doorkeeper > 1.4.0 and < 4.3
-- Grape > 0.10 and < 1.0
+- Grape > 0.10 and <= 1.0
 
 Please submit pull requests and Travis env bumps for newer dependency versions.
 
@@ -39,7 +39,7 @@ Please submit pull requests and Travis env bumps for newer dependency versions.
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'wine_bouncer', '~> 1.0.1'
+gem 'wine_bouncer', '~> 1.0.2'
 ```
 
 And then execute:

--- a/lib/wine_bouncer/configuration.rb
+++ b/lib/wine_bouncer/configuration.rb
@@ -20,12 +20,12 @@ module WineBouncer
     end
 
     def define_resource_owner &block
-      fail(ArgumentError, 'define_resource_owner expects a block in the configuration') unless block_given?
+      raise(ArgumentError, 'define_resource_owner expects a block in the configuration') unless block_given?
       @defined_resource_owner = block
     end
 
     def defined_resource_owner
-      fail(Errors::UnconfiguredError, 'Please define define_resource_owner to configure the resource owner') unless @defined_resource_owner
+      raise(Errors::UnconfiguredError, 'Please define define_resource_owner to configure the resource owner') unless @defined_resource_owner
       @defined_resource_owner
     end
 
@@ -41,7 +41,7 @@ module WineBouncer
   end
 
   def self.configuration
-    @configuration || fail(Errors::UnconfiguredError.new)
+    @configuration || raise(Errors::UnconfiguredError.new)
   end
 
   def self.configuration=(config)
@@ -59,7 +59,7 @@ module WineBouncer
     config
   end
 
-  private
+  private_class_method
 
   ###
   # Returns a new configuration or existing one.

--- a/lib/wine_bouncer/oauth2.rb
+++ b/lib/wine_bouncer/oauth2.rb
@@ -100,7 +100,7 @@ module WineBouncer
     private
 
     def set_auth_strategy(strategy)
-      @auth_strategy = WineBouncer::AuthStrategies.const_get("#{strategy.to_s.capitalize}").new
+      @auth_strategy = WineBouncer::AuthStrategies.const_get(strategy.to_s.capitalize.to_s).new
     end
   end
 end

--- a/lib/wine_bouncer/version.rb
+++ b/lib/wine_bouncer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WineBouncer
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'.freeze
 end

--- a/spec/lib/wine_bouncer/auth_strategies/default_spec.rb
+++ b/spec/lib/wine_bouncer/auth_strategies/default_spec.rb
@@ -15,14 +15,14 @@ describe ::WineBouncer::AuthStrategies::Default do
       context_double = double()
       allow(context_double).to receive(:options) { auth_context }
       klass.api_context = context_double
-      expect(klass.send :endpoint_authorizations).to eq(scopes_hash)
+      expect(klass.send(:endpoint_authorizations)).to eq(scopes_hash)
     end
 
     it 'returns nil when the authentication key has no hash key.' do
       context_double = double()
       allow(context_double).to receive(:options) { { route_options: { some: scopes_hash } } }
       klass.api_context = context_double
-      expect(klass.send :endpoint_authorizations).to eq(nil)
+      expect(klass.send(:endpoint_authorizations)).to eq(nil)
     end
   end
 

--- a/spec/lib/wine_bouncer/auth_strategies/swagger_spec.rb
+++ b/spec/lib/wine_bouncer/auth_strategies/swagger_spec.rb
@@ -15,14 +15,14 @@ describe ::WineBouncer::AuthStrategies::Swagger do
       context_double = double()
       allow(context_double).to receive(:options) { auth_context }
       klass.api_context = context_double
-      expect(klass.send :endpoint_authorizations).to eq(scopes_map)
+      expect(klass.send(:endpoint_authorizations)).to eq(scopes_map)
     end
 
     it 'returns nil when the authentication key has no hash key.' do
       context_double = double()
       allow(context_double).to receive(:options) { { route_options: { some: scopes_map } } }
       klass.api_context = context_double
-      expect(klass.send :endpoint_authorizations).to eq(nil)
+      expect(klass.send(:endpoint_authorizations)).to eq(nil)
     end
   end
 
@@ -31,14 +31,14 @@ describe ::WineBouncer::AuthStrategies::Swagger do
       context_double = double()
       allow(context_double).to receive(:options) { auth_context }
       klass.api_context = context_double
-      expect(klass.send :has_authorizations?).to eq(true)
+      expect(klass.send(:has_authorizations?)).to eq(true)
     end
 
     it 'returns false when there is no authentication key.' do
       context_double = double()
       allow(context_double).to receive(:options) { { route_options: { some: scopes_map } } }
       klass.api_context = context_double
-      expect(klass.send :has_authorizations?).to eq(false)
+      expect(klass.send(:has_authorizations?)).to eq(false)
     end
   end
 
@@ -47,14 +47,14 @@ describe ::WineBouncer::AuthStrategies::Swagger do
       context_double = double()
       allow(context_double).to receive(:options) { auth_context }
       klass.api_context = context_double
-      expect(klass.send :authorization_type_oauth2).to eq(scopes)
+      expect(klass.send(:authorization_type_oauth2)).to eq(scopes)
     end
 
     it 'returns nil when there is no oauth2 key.' do
       context_double = double()
       allow(context_double).to receive(:options) { { route_options: { authorizations: { no_oauth: scopes } } } }
       klass.api_context = context_double
-      expect(klass.send :authorization_type_oauth2).to eq(nil)
+      expect(klass.send(:authorization_type_oauth2)).to eq(nil)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,8 +16,8 @@
 # users commonly want.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
+require 'simplecov'
+SimpleCov.start
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate

--- a/wine_bouncer.gemspec
+++ b/wine_bouncer.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'grape', '~> 0.10', '<= 1.0'
+  spec.add_runtime_dependency 'grape', '<= 1.0.0'
   spec.add_runtime_dependency 'doorkeeper', '>= 1.4', '< 4.3'
 
   spec.add_development_dependency 'railties'

--- a/wine_bouncer.gemspec
+++ b/wine_bouncer.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'grape', '~> 0.10', '< 1.0'
+  spec.add_runtime_dependency 'grape', '~> 0.10', '<= 1.0'
   spec.add_runtime_dependency 'doorkeeper', '>= 1.4', '< 4.3'
 
   spec.add_development_dependency 'railties'


### PR DESCRIPTION
hey i updated the gemspec to allow grape v1.0.0 and all the tests still pass.

while I was at it, I also updated the code-climate-reporter since it was out of date.