### PR TITLE
Increase grape version dependency to less than 1.2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,17 @@ env:
 
 - rails=4.2.6 grape=0.15.0 doorkeeper=3.1.0
 - rails=4.2.6 grape=1.0.0 doorkeeper=3.1.0
+- rails=4.2.6 grape=1.1.0 doorkeeper=3.1.0
 - rails=4.2.6 grape=0.16.2 doorkeeper=4.2.0
 - rails=4.2.6 grape=0.16.2 doorkeeper=4.4.1
+- rails=4.2.6 grape=1.1.0 doorkeeper=4.2.0
+- rails=4.2.6 grape=1.1.0 doorkeeper=4.4.1
 - rails=5.0.0 grape=0.16.2 doorkeeper=4.0.0
 - rails=5.0.0 grape=0.16.2 doorkeeper=4.1.0
 - rails=5.0.0 grape=0.16.2 doorkeeper=4.2.0
 - rails=5.0.0 grape=1.0.0 doorkeeper=4.2.0
+- rails=5.0.0 grape=1.1.0 doorkeeper=4.2.0
+- rails=5.0.0 grape=1.1.0 doorkeeper=4.4.1
 
 addons:
   code_climate:

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-ENV['grape'] ||= '1.0.0'
+ENV['grape'] ||= '1.1.0'
 ENV['rails'] ||= '5.0.0'
 ENV['doorkeeper'] ||= '4.0.0'
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Table of Contents
 ## Requirements
 - Ruby > 2.1
 - Doorkeeper > 1.4.0 and < 4.3
-- Grape > 0.10 and < 1.1
+- Grape > 0.10 and < 1.2
 
 Please submit pull requests and Travis env bumps for newer dependency versions.
 

--- a/wine_bouncer.gemspec
+++ b/wine_bouncer.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'grape', '>= 0.10', '< 1.1'
+  spec.add_runtime_dependency 'grape', '>= 0.10', '< 1.2'
   spec.add_runtime_dependency 'doorkeeper', '>= 1.4', '< 5.0'
 
   spec.add_development_dependency 'railties'


### PR DESCRIPTION
This allows grape & wine_bouncer apps to update grape to 1.1.0.