### PR TITLE
Add support for doorkeeper < 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
 - rails=4.2.6 grape=0.15.0 doorkeeper=3.1.0
 - rails=4.2.6 grape=1.0.0 doorkeeper=3.1.0
 - rails=4.2.6 grape=0.16.2 doorkeeper=4.2.0
+- rails=4.2.6 grape=0.16.2 doorkeeper=4.4.1
 - rails=5.0.0 grape=0.16.2 doorkeeper=4.0.0
 - rails=5.0.0 grape=0.16.2 doorkeeper=4.1.0
 - rails=5.0.0 grape=0.16.2 doorkeeper=4.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Changelog
 =========
 
 ## Unreleased
-
+Support for Doorkeeper < 5.0
 
 ## 1.0.2
 * [#68](https://github.com/antek-drzewiecki/wine_bouncer/pull/68): Update dependency to allow grape v1. Thanks @chandeeland

--- a/wine_bouncer.gemspec
+++ b/wine_bouncer.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'grape', '>= 0.10', '< 1.1'
-  spec.add_runtime_dependency 'doorkeeper', '>= 1.4', '< 4.3'
+  spec.add_runtime_dependency 'doorkeeper', '>= 1.4', '< 5.0'
 
   spec.add_development_dependency 'railties'
   spec.add_development_dependency 'bundler', '~> 1.7'


### PR DESCRIPTION
Add support for Doorkeeper < 5.0. 

Doorkeeper 4.4.0 includes a fix for https://nvd.nist.gov/vuln/detail/CVE-2018-1000211.

This could replace https://github.com/antek-drzewiecki/wine_bouncer/pull/71.



