### PR TITLE
Update for grape 1.2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,39 @@
 sudo: false
 before_install:
-- gem update bundler
-- bundle --version
+- gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+- gem install bundler -v '< 2'
 language: ruby
 cache: bundler
 rvm:
-- 2.3.7
-- 2.4.4
-- 2.5.1
+- 2.3.8
+- 2.4.5
+- 2.5.3
+- 2.6.0
 
 env:
-- rails=4.2.10 grape=0.16.2 doorkeeper=3.1.0
-- rails=4.2.10 grape=0.16.2 doorkeeper=4.2.0
-- rails=4.2.10 grape=1.1.0 doorkeeper=4.4.1
-- rails=5.0.0 grape=0.16.2 doorkeeper=4.4.1
-- rails=5.0.0 grape=1.0.0 doorkeeper=4.2.0
-- rails=5.0.0 grape=1.1.0 doorkeeper=4.4.1
-- rails=5.0.0 grape=1.1.0 doorkeeper=5.0.0
+- rails=4.2.11 grape=0.16.2 doorkeeper=3.1.0
+- rails=4.2.11 grape=0.16.2 doorkeeper=4.2.6
+- rails=4.2.11 grape=1.1.0 doorkeeper=4.4.3
+- rails=5.0.7.1 grape=0.16.2 doorkeeper=4.4.3
+- rails=5.0.7.1 grape=0.19.2 doorkeeper=4.4.3
+- rails=5.0.7.1 grape=1.0.0 doorkeeper=4.4.3
+- rails=5.0.7.1 grape=1.1.0 doorkeeper=4.4.3
+- rails=5.0.7.1 grape=1.2.3 doorkeeper=4.4.3
+- rails=5.0.7.1 grape=1.0.0 doorkeeper=5.0.2
+- rails=5.0.7.1 grape=1.1.0 doorkeeper=5.0.2
+- rails=5.0.7.1 grape=1.2.3 doorkeeper=5.0.2
+- rails=5.1.6.1 grape=1.0.0 doorkeeper=4.4.3
+- rails=5.1.6.1 grape=1.1.0 doorkeeper=4.4.3
+- rails=5.1.6.1 grape=1.2.3 doorkeeper=4.4.3
+- rails=5.1.6.1 grape=1.0.0 doorkeeper=5.0.2
+- rails=5.1.6.1 grape=1.1.0 doorkeeper=5.0.2
+- rails=5.1.6.1 grape=1.2.3 doorkeeper=5.0.2
+- rails=5.2.2 grape=1.0.0 doorkeeper=4.4.3
+- rails=5.2.2 grape=1.1.0 doorkeeper=4.4.3
+- rails=5.2.2 grape=1.2.3 doorkeeper=4.4.3
+- rails=5.2.2 grape=1.0.0 doorkeeper=5.0.2
+- rails=5.2.2 grape=1.1.0 doorkeeper=5.0.2
+- rails=5.2.2 grape=1.2.3 doorkeeper=5.0.2
 
 addons:
   code_climate:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
 - rails=5.0.0 grape=0.16.2 doorkeeper=4.4.1
 - rails=5.0.0 grape=1.0.0 doorkeeper=4.2.0
 - rails=5.0.0 grape=1.1.0 doorkeeper=4.4.1
+- rails=5.0.0 grape=1.1.0 doorkeeper=5.0.0
 
 addons:
   code_climate:

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 ENV['grape'] ||= '1.1.0'
 ENV['rails'] ||= '5.0.0'
-ENV['doorkeeper'] ||= '4.0.0'
+ENV['doorkeeper'] ||= '5.0.0'
 
 ruby '>= 2.2.2' if ENV['rails'][0].to_i > 4
 

--- a/lib/wine_bouncer/extension.rb
+++ b/lib/wine_bouncer/extension.rb
@@ -17,6 +17,8 @@ module WineBouncer
       # end
     end
 
-    Grape::API.extend self
+    # Grape::API::Instance is defined in grape 1.2.0 or above
+    grape_api = defined?(Grape::API::Instance) ? Grape::API::Instance : Grape::API
+    grape_api.extend self
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 20140915160601) do
     t.text 'redirect_uri', null: false
     t.datetime 'created_at'
     t.datetime 'updated_at'
+    t.boolean "confidential", default: true, null: false
   end
 
   add_index 'oauth_applications', ['uid'], name: 'index_oauth_applications_on_uid', unique: true

--- a/wine_bouncer.gemspec
+++ b/wine_bouncer.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'grape', '>= 0.10', '< 1.2'
-  spec.add_runtime_dependency 'doorkeeper', '>= 1.4', '< 5.0'
+  spec.add_runtime_dependency 'doorkeeper', '>= 1.4', '< 6.0'
 
   spec.add_development_dependency 'railties'
   spec.add_development_dependency 'bundler', '~> 1.7'

--- a/wine_bouncer.gemspec
+++ b/wine_bouncer.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'grape', '>= 0.10', '< 1.2'
+  spec.add_runtime_dependency 'grape', '>= 0.10', '< 1.3'
   spec.add_runtime_dependency 'doorkeeper', '>= 1.4', '< 6.0'
 
   spec.add_development_dependency 'railties'


### PR DESCRIPTION
This PR should change wine_bounce to be able to use with grape 1.2.x. It also includes change in #77